### PR TITLE
Simplify

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -61,7 +61,5 @@ type Wither interface {
 	With(keyvals ...interface{}) Logger
 }
 
-// NewDiscardLogger returns a logger that does not log anything.
-func NewDiscardLogger() Logger {
-	return LoggerFunc(func(...interface{}) error { return nil })
-}
+// Discard is a no-op logger.
+var Discard = LoggerFunc(func(...interface{}) error { return nil })

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -82,17 +82,15 @@ func TestWithConcurrent(t *testing.T) {
 }
 
 func BenchmarkDiscard(b *testing.B) {
-	logger := log.NewDiscardLogger()
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		logger.Log("k", "v")
+		log.Discard("k", "v")
 	}
 }
 
 func BenchmarkOneWith(b *testing.B) {
-	logger := log.NewDiscardLogger()
-	logger = log.With(logger, "k", "v")
+	logger := log.With(log.Discard, "k", "v")
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -101,7 +99,7 @@ func BenchmarkOneWith(b *testing.B) {
 }
 
 func BenchmarkTwoWith(b *testing.B) {
-	logger := log.NewDiscardLogger()
+	logger := log.Logger(log.Discard)
 	for i := 0; i < 2; i++ {
 		logger = log.With(logger, "k", "v")
 	}
@@ -113,7 +111,7 @@ func BenchmarkTwoWith(b *testing.B) {
 }
 
 func BenchmarkTenWith(b *testing.B) {
-	logger := log.NewDiscardLogger()
+	logger := log.Logger(log.Discard)
 	for i := 0; i < 10; i++ {
 		logger = log.With(logger, "k", "v")
 	}

--- a/log/value.go
+++ b/log/value.go
@@ -14,28 +14,15 @@ type Valuer func() interface{}
 // a Valuer replaced by their generated value. If no Valuers are found, the
 // original slice is returned.
 func BindValues(keyvals ...interface{}) []interface{} {
-	if !containsValuer(keyvals) {
-		return keyvals
-	}
-
 	bound := make([]interface{}, len(keyvals))
-	copy(bound, keyvals)
-	for i := 1; i < len(bound); i += 2 {
-		if v, ok := bound[i].(Valuer); ok {
+	for i, val := range keyvals {
+		if v, ok := val.(Valuer); ok {
 			bound[i] = v()
+		} else {
+			bound[i] = val
 		}
 	}
-
 	return bound
-}
-
-func containsValuer(keyvals []interface{}) bool {
-	for i := 1; i < len(keyvals); i += 2 {
-		if _, ok := keyvals[i].(Valuer); ok {
-			return true
-		}
-	}
-	return false
 }
 
 // Timestamp returns a Valuer that invokes the underlying function when bound,

--- a/log/value_test.go
+++ b/log/value_test.go
@@ -52,8 +52,7 @@ func TestValueBinding(t *testing.T) {
 }
 
 func BenchmarkValueBindingTimestamp(b *testing.B) {
-	logger := log.NewDiscardLogger()
-	logger = log.With(logger, "ts", log.DefaultTimestamp)
+	logger := log.With(log.Discard, "ts", log.DefaultTimestamp)
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -62,8 +61,7 @@ func BenchmarkValueBindingTimestamp(b *testing.B) {
 }
 
 func BenchmarkValueBindingCaller(b *testing.B) {
-	logger := log.NewDiscardLogger()
-	logger = log.With(logger, "caller", log.DefaultCaller)
+	logger := log.With(log.Discard, "caller", log.DefaultCaller)
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {


### PR DESCRIPTION
This change set does two simplifications:
1. Removes `NewDiscardLogger` in favour of a global `Discard` Logger as there is no need to have different instances of it.
2. Removes fast path from `BindValues` after observing a slight improvement in the benchmarks.
