### PR TITLE
Faster value binding.

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -24,12 +24,16 @@ func With(logger Logger, keyvals ...interface{}) Logger {
 }
 
 type withLogger struct {
-	logger  Logger
-	keyvals []interface{}
+	logger    Logger
+	keyvals   []interface{}
+	hasValuer bool
 }
 
 func (l *withLogger) Log(keyvals ...interface{}) error {
-	return l.logger.Log(append(BindValues(l.keyvals...), keyvals...)...)
+	if l.hasValuer {
+		return l.logger.Log(append(BindValues(l.keyvals...), keyvals...)...)
+	}
+	return l.logger.Log(append(l.keyvals, keyvals...)...)
 }
 
 func (l *withLogger) With(keyvals ...interface{}) Logger {
@@ -39,8 +43,9 @@ func (l *withLogger) With(keyvals ...interface{}) Logger {
 	// would violate the Logger interface contract.
 	n := len(l.keyvals) + len(keyvals)
 	return &withLogger{
-		logger:  l.logger,
-		keyvals: append(l.keyvals, keyvals...)[:n:n],
+		logger:    l.logger,
+		keyvals:   append(l.keyvals, keyvals...)[:n:n],
+		hasValuer: l.hasValuer || ContainsValuer(keyvals),
 	}
 }
 

--- a/log/log.go
+++ b/log/log.go
@@ -30,10 +30,11 @@ type withLogger struct {
 }
 
 func (l *withLogger) Log(keyvals ...interface{}) error {
+	kvs := append(l.keyvals, keyvals...)
 	if l.hasValuer {
-		return l.logger.Log(append(BindValues(l.keyvals...), keyvals...)...)
+		BindValues(kvs[:len(l.keyvals)])
 	}
-	return l.logger.Log(append(l.keyvals, keyvals...)...)
+	return l.logger.Log(kvs...)
 }
 
 func (l *withLogger) With(keyvals ...interface{}) Logger {

--- a/log/value.go
+++ b/log/value.go
@@ -11,13 +11,8 @@ import (
 type Valuer func() interface{}
 
 // BindValues returns a slice with all value elements (odd indexes) containing
-// a Valuer replaced by their generated value. If no Valuers are found, the
-// original slice is returned.
+// a Valuer replaced by their generated value.
 func BindValues(keyvals ...interface{}) []interface{} {
-	if !containsValuer(keyvals) {
-		return keyvals
-	}
-
 	bound := make([]interface{}, len(keyvals))
 	copy(bound, keyvals)
 	for i := 1; i < len(bound); i += 2 {
@@ -25,11 +20,12 @@ func BindValues(keyvals ...interface{}) []interface{} {
 			bound[i] = v()
 		}
 	}
-
 	return bound
 }
 
-func containsValuer(keyvals []interface{}) bool {
+// ContainsValuer returns true if any of the value elements (odd indexes)
+// contain a Valuer.
+func ContainsValuer(keyvals []interface{}) bool {
 	for i := 1; i < len(keyvals); i += 2 {
 		if _, ok := keyvals[i].(Valuer); ok {
 			return true

--- a/log/value.go
+++ b/log/value.go
@@ -10,17 +10,14 @@ import (
 // dynamic value which is re-evaluated with each log event.
 type Valuer func() interface{}
 
-// BindValues returns a slice with all value elements (odd indexes) containing
-// a Valuer replaced by their generated value.
-func BindValues(keyvals ...interface{}) []interface{} {
-	bound := make([]interface{}, len(keyvals))
-	copy(bound, keyvals)
-	for i := 1; i < len(bound); i += 2 {
-		if v, ok := bound[i].(Valuer); ok {
-			bound[i] = v()
+// BindValues replaces all value elements (odd indexes) containing a Valuer
+// with their generated value.
+func BindValues(keyvals []interface{}) {
+	for i := 1; i < len(keyvals); i += 2 {
+		if v, ok := keyvals[i].(Valuer); ok {
+			keyvals[i] = v()
 		}
 	}
-	return bound
 }
 
 // ContainsValuer returns true if any of the value elements (odd indexes)


### PR DESCRIPTION
Improve performance of value binding by checking for Valuers in With instead of Log.
- Always copy keyvals in BindValues.
- Export ContainsValuer and use in With.
- Add hasValuer bool field to withLogger.
